### PR TITLE
Merge all branches that use the full power of solve_ivp, i.e. without the py-pde wrapper

### DIFF
--- a/LMAHeureuxPorosityDiffV2.py
+++ b/LMAHeureuxPorosityDiffV2.py
@@ -178,6 +178,8 @@ class LMAHeureuxPorosityDiff(PDEBase):
         CC = y[self.CC_sl]
         cCa = y[self.cCa_sl]
         cCO3 = y[self.cCO3_sl]
+        # Set a limit on cCO3, which turns negative so quickly.
+        # cCO3 = np.fmax(cCO3, 0)
         Phi = y[self.Phi_sl]   
 
         rhs = LMAHeureuxPorosityDiff.pde_rhs(CA, CC, cCa, cCO3, Phi, self.KRat, \
@@ -198,6 +200,8 @@ class LMAHeureuxPorosityDiff(PDEBase):
         CC = y[self.CC_sl]
         cCa = y[self.cCa_sl]
         cCO3 = y[self.cCO3_sl]
+        # Set a limit on cCO3, which turns negative so quickly.
+        # cCO3 = np.fmax(cCO3, 0)
         Phi = y[self.Phi_sl]  
 
         jacob_csr = csr_matrix(Jacobian(CA, CC, cCa, cCO3, Phi, \
@@ -313,6 +317,10 @@ class LMAHeureuxPorosityDiff(PDEBase):
                                         cCO3_grad[i] + Da * (1 - Phi[i]) * \
                                         (delta - cCO3[i]) * (coA[i] - \
                                         lambda_ * coC[i])/Phi[i]
+            if cCO3[i]<0 and rate[3 * no_depths + i] < 0:
+                rate[3 * no_depths + i] *= -1
+            """             if cCO3[i] > 2 and rate[3 * no_depths + i] > 0:
+                rate[3 * no_depths + i] *= -1    """      
 
             dPhi[i] = auxcon * F[i] * (Phi[i] ** 3) / (1 - Phi[i])        
 

--- a/ScenarioA.py
+++ b/ScenarioA.py
@@ -58,7 +58,7 @@ PhiInfty = 0.01
 Xstar = D0Ca / sedimentationrate
 Tstar = Xstar / sedimentationrate 
 
-number_of_depths = 2000
+number_of_depths = 500
 
 max_depth = 500
 
@@ -112,7 +112,7 @@ print("Time taken for solve_ivp is {0:.2f}s.".format(end_computing - start_compu
 print()
 print("sol.t = {0}, sol.y =  {1}".format(sol.t, sol.y)) """
 
-fig, (ax0, ax1, ax2, ax3, ax4) = plt.subplots(1, 5)
+fig, (ax0, ax1, ax2, ax3, ax4) = plt.subplots(5, 1, figsize = (5, 25))
 ax0.plot(depths, (sol.y)[slices_for_all_fields[0], -1], label = "CA")
 ax0.legend(loc='upper right')
 ax1.plot(depths, (sol.y)[slices_for_all_fields[1], -1], label = "CC")


### PR DESCRIPTION
Currently there are seven branches in this repo, including main.

The Fiadeiro-Veronis branch achieves the desired result:
it integrates smoothly, without setting any limits on the states.
And the end result, after integrating over Tstar, is very similar to Fig 3e from l'Heureux.

It turns out that an explicit (in time) solver (_RK23_, i.e. Runge Kutta) from _solve_ivp_ performs equally well as an implicit (in time) solver like _BDF_ from _solve_ivp_, in the sense that both algorithms produce virtually the same plot after integrating over Tstar; the differences are really minor and can only be seen by blinking the two plots one after the other. This means the implicit solvers from solve_ivp and the Jacobian do not seem to be needed for computing Scenario A from l'Heureux.

Using _RK23_ it takes 27 minutes on a AMD EPYC 7402P 24-Core Processor, with 48 logical cores to cover Tstar, while with _BDF_ it takes 3 hours and 3 minutes.
Towards the end of the integration the memory used is about 12 GB voor _RK23_ and something similar for _BDF_. So really huge.

We want to retain the full power of _solve_ivp_ and the Jacobian computation for integrating other scenarios that may need implicit (in time) solvers. This means we want to keep a branch that deploys the full power of _solve_ivp_, i.e. _solve_ivp_ without the py-pde wrapper, the _Use_solve_ivp_without_py-pde_wrapper_ branch. So we want to merge all branches derived from _Use_solve_ivp_without_py-pde_wrapper_ into _Use_solve_ivp_without_py-pde_wrapper_.

Yet it would also be good to have a branch that integrates Scenario A fast and with a low memory footprint. This should become the main branch. That fast and efficient integrator for Scenario A can possibly be provided by the py-pde solvers, i.e. using the full py-pde framework, part of which was abandoned in the _Use_solve_ivp_without_py-pde_wrapper_ branch.