### PR TITLE
Merge all branches that use the full power of solve_ivp, i.e. without the py-pde wrapper

### DIFF
--- a/LMAHeureuxPorosityDiffV2.py
+++ b/LMAHeureuxPorosityDiffV2.py
@@ -206,44 +206,59 @@ class LMAHeureuxPorosityDiff(PDEBase):
         # CA_grad = CA.gradient(self.bc_CA)[0]
         # Instead of a central differencing gradient, 
         # construct a backward differencing gradient, for better stability.
-        CA_grad = CA.copy()
-        CA_grad.data[:] = 0
+        CA_grad_back = CA.copy()
+        CA_grad_forw = CA.copy()
+        CA_grad_back.data[:] = 0
+        CA_grad_forw.data[:] = 0
         CA.set_ghost_cells(self.bc_CA)
-        self.backward_diff(CA._data_full, out = CA_grad.data)
+        self.backward_diff(CA._data_full, out = CA_grad_back.data)
+        self.forward_diff(CA._data_full, out = CA_grad_forw.data)
 
         # CC_grad = CC.gradient(self.bc_CC)[0]
         # Instead of a central differencing gradient, 
         # construct a backward differencing gradient, for better stability.
-        CC_grad = CC.copy()
-        CC_grad.data[:] = 0
+        CC_grad_back = CC.copy()
+        CC_grad_forw = CC.copy()
+        CC_grad_back.data[:] = 0
+        CC_grad_forw.data[:] = 0
         CC.set_ghost_cells(self.bc_CC)
-        self.backward_diff(CC._data_full, out = CC_grad.data)
+        self.backward_diff(CC._data_full, out = CC_grad_back.data)
+        self.forward_diff(CC._data_full, out = CC_grad_forw.data)
 
         # cCa_grad = cCa.gradient(self.bc_cCa)[0]
         # Instead of a central differencing gradient, 
         # construct a backward differencing gradient, for better stability.
-        cCa_grad = cCa.copy()
-        cCa_grad.data[:] = 0
+        cCa_grad_back = cCa.copy()
+        cCa_grad_forw = cCa.copy()
+        cCa_grad_back.data[:] = 0
+        cCa_grad_forw.data[:] = 0
         cCa.set_ghost_cells(self.bc_cCa)
-        self.forward_diff(cCa._data_full, out = cCa_grad.data)
+        self.backward_diff(cCa._data_full, out = cCa_grad_back.data)
+        self.forward_diff(cCa._data_full, out = cCa_grad_forw.data)
         cCa_laplace = cCa.laplace(self.bc_cCa)
 
         # cCO3_grad = cCO3.gradient(self.bc_cCO3)[0]
         # Instead of a central differencing gradient, 
         # construct a backward differencing gradient, for better stability.
-        cCO3_grad = cCO3.copy()
-        cCO3_grad.data[:] = 0
+        cCO3_grad_back = cCO3.copy()
+        cCO3_grad_forw = cCO3.copy()
+        cCO3_grad_back.data[:] = 0
+        cCO3_grad_forw.data[:] = 0
         cCO3.set_ghost_cells(self.bc_cCO3)
-        self.forward_diff(cCO3._data_full, out = cCO3_grad.data)
+        self.backward_diff(cCO3._data_full, out = cCO3_grad_back.data)
+        self.forward_diff(cCO3._data_full, out = cCO3_grad_forw.data)
         cCO3_laplace = cCO3.laplace(self.bc_cCO3)
 
         # Phi_grad = Phi.gradient(self.bc_Phi)[0]
         # Instead of a central differencing gradient, 
         # construct a backward differencing gradient, for better stability.
-        Phi_grad = Phi.copy()
-        Phi_grad.data[:] = 0
+        Phi_grad_back = Phi.copy()
+        Phi_grad_forw = Phi.copy()
+        Phi_grad_back.data[:] = 0
+        Phi_grad_forw.data[:] = 0
         Phi.set_ghost_cells(self.bc_Phi)
-        self.forward_diff(Phi._data_full, out = Phi_grad.data)
+        self.backward_diff(Phi._data_full, out = Phi_grad_back.data)
+        self.forward_diff(Phi._data_full, out = Phi_grad_forw.data)
         Phi_laplace = Phi.laplace(self.bc_Phi)
 
         rhs = LMAHeureuxPorosityDiff.pde_rhs(CA.data, CC.data, cCa.data, \
@@ -251,10 +266,11 @@ class LMAHeureuxPorosityDiff(PDEBase):
             self.m1, self.m2, self.n1, self.n2, self.nu1, self.nu2, \
             self.not_too_deep, self.not_too_shallow, self.presum, self.rhorat, \
             self.lambda_, self.Da, self.dCa, self.dCO3, self.delta, self.auxcon, \
-            CA_grad.data, CC_grad.data, cCa_grad.data, \
-            cCa_laplace.data, cCO3_grad.data, cCO3_laplace.data, \
-            Phi_grad.data, Phi_laplace.data, \
-            no_depths = self.Depths.shape[0])
+            CA_grad_back.data, CA_grad_forw.data, CC_grad_back.data, \
+            CC_grad_forw.data, cCa_grad_back.data, cCa_grad_forw.data, \
+            cCa_laplace.data, cCO3_grad_back.data, cCO3_grad_forw.data,\
+            cCO3_laplace.data, Phi_grad_back.data, Phi_grad_forw.data, \
+            Phi_laplace.data, no_depths = self.Depths.shape[0])
 
         # print("Right-hand side evaluated")
 
@@ -302,6 +318,34 @@ class LMAHeureuxPorosityDiff(PDEBase):
 
         Phi = y[self.Phi_sl]   
         return np.amax(Phi) - 1
+
+    def zeros_U(self, t, y, pbar, state): 
+        """ solve_ivp demands that I add these two extra aguments, i.e.
+        pbar and state, as in jac, where I need them for 
+        tqdm progress display.
+        However, for this rhs calculation, they are redundant. """
+
+        Phi = y[self.Phi_sl]   
+        F = 1 - np.exp(10 - 10 / Phi)
+        U = self.presum + self.rhorat * Phi ** 3 * F / (1 - Phi)
+        # Assume that U is positive at every depth at the beginning
+        # of the integration, so U will become zero first where it
+        # is smallest.
+        return np.amin(U)
+
+    def zeros_W(self, t, y, pbar, state): 
+        """ solve_ivp demands that I add these two extra aguments, i.e.
+        pbar and state, as in jac, where I need them for 
+        tqdm progress display.
+        However, for this rhs calculation, they are redundant. """
+
+        Phi = y[self.Phi_sl]   
+        F = 1 - np.exp(10 - 10 / Phi)
+        W = self.presum - self.rhorat * Phi ** 2 * F
+        # Assume that W is negative at every depth at the beginning
+        # of the integration, so U will become zero first where it is
+        # largest or least negative.
+        return np.amax(W)
 
 
     def jac(self, t, y, pbar, state):
@@ -369,10 +413,11 @@ class LMAHeureuxPorosityDiff(PDEBase):
             m1, m2, n1, n2, nu1, nu2, \
             not_too_deep, not_too_shallow, presum, rhorat, \
             lambda_, Da, dCa, dCO3, delta, auxcon, \
-            CA_grad, CC_grad, cCa_grad, \
-            cCa_laplace, cCO3_grad, cCO3_laplace, \
-            Phi_grad, Phi_laplace, \
-            no_depths):
+            CA_grad_back, CA_grad_forw, CC_grad_back, \
+            CC_grad_forw, cCa_grad_back, cCa_grad_forw, \
+            cCa_laplace, cCO3_grad_back, cCO3_grad_forw,\
+            cCO3_laplace, Phi_grad_back, Phi_grad_forw, \
+            Phi_laplace, no_depths):
         """ compiled helper function evaluating right hand side """
 
         denominator = np.empty(no_depths)
@@ -396,8 +441,35 @@ class LMAHeureuxPorosityDiff(PDEBase):
         dPhi = np.empty(no_depths)
         dW_dx = np.empty(no_depths)
         one_minus_Phi = np.empty(no_depths)
+        CA_grad = np.empty(no_depths)
+        CC_grad = np.empty(no_depths)
+        cCa_grad = np.empty(no_depths)
+        cCO3_grad = np.empty(no_depths)
+        Phi_grad = np.empty(no_depths)
 
         for i in prange(no_depths):
+            F[i] = 1 - np.exp(10 - 10 / Phi[i])
+
+            U[i] = presum + rhorat * Phi[i] ** 3 * F[i]/ (1 - Phi[i])
+
+            if U[i] > 0:
+                CA_grad[i] = CA_grad_back[i]
+                CC_grad[i] = CC_grad_back[i]
+            else:
+                CA_grad[i] = CA_grad_forw[i]
+                CC_grad[i] = CC_grad_forw[i]
+
+            W[i] = presum - rhorat * Phi[i] ** 2 * F[i]
+
+            if W[i] < 0:
+                cCa_grad[i] = cCa_grad_forw[i]
+                cCO3_grad[i] = cCO3_grad_forw[i]
+                Phi_grad[i] = Phi_grad_forw[i]
+            else:
+                cCa_grad[i] = cCa_grad_back[i]
+                cCO3_grad[i] = cCO3_grad_back[i]
+                Phi_grad[i] = Phi_grad_back[i]
+
             # Implementing equation 6 from l'Heureux.
             denominator[i] = 1 - 2 * np.log(Phi[i])
             common_helper1[i] = Phi[i]/denominator[i]
@@ -407,12 +479,6 @@ class LMAHeureuxPorosityDiff(PDEBase):
                                  + common_helper1[i] * cCa_laplace[i])
             helper_cCO3_grad[i] = dCO3 * (common_helper2[i] * cCO3_grad[i] \
                                  + common_helper1[i] * cCO3_laplace[i])            
-            F[i] = 1 - np.exp(10 - 10 / Phi[i])
-
-            U[i] = presum + rhorat * Phi[i] ** 3 * F[i]/ (1 - Phi[i])
-    
-            W[i] = presum - rhorat * Phi[i] ** 2 * F[i]
-
             two_factors[i] = cCa[i] * cCO3[i]
             two_factors_upp_lim[i] = min(two_factors[i],1)
             two_factors_low_lim[i] = max(two_factors[i],1)

--- a/ScenarioA.py
+++ b/ScenarioA.py
@@ -109,9 +109,9 @@ number_of_progress_updates = 100000
 start_computing = time.time()
 with tqdm(total=number_of_progress_updates, unit="‰") as pbar:
     sol = solve_ivp(fun = eq.fun_numba, t_span = (0, end_time), y0 = y0, \
-                atol = 1e-10, rtol = 1e-10, t_eval= t_eval, \
+                atol = 1e-8, rtol = 1e-8, t_eval= t_eval, \
                 events = [eq.zeros, eq.zeros_CA, eq.zeros_CC, \
-                eq.ones_CA_plus_CC, eq.ones_Phi],  \
+                eq.ones_CA_plus_CC, eq.ones_Phi, eq.zeros_U, eq.zeros_W],  \
                 method="BDF", dense_output= True,\
                 first_step = None, jac = eq.jac, \
                 args=[pbar, [0, 1/number_of_progress_updates]])
@@ -128,26 +128,35 @@ print("Status = {0}".format(sol.status))
 print()
 print("Success = {0}".format(sol.success))
 print()
-v = sol.t_events[0]
-print(("Times, in years, at which any field at any depth was below zero: "\
-      +', '.join(['%.2f']*len(v))+"") % tuple([Tstar * time for time in v]))
+f = sol.t_events[0]
+print(("Times, in years, at which any field at any depth crossed zero: "\
+      +', '.join(['%.2f']*len(f))+"") % tuple([Tstar * time for time in f]))
 print()
-w = sol.t_events[1]
-print(("Times, in years, at which CA at any depth was below zero: "\
-      +', '.join(['%.2f']*len(w))+"") % tuple([Tstar * time for time in w]))
+g = sol.t_events[1]
+print(("Times, in years, at which CA at any depth crossed zero: "\
+      +', '.join(['%.2f']*len(g))+"") % tuple([Tstar * time for time in g]))
 print()
-x = sol.t_events[2]
-print(("Times, in years, at which CC at any depth was below zero: "\
-      +', '.join(['%.2f']*len(x))+"") % tuple([Tstar * time for time in x]))
+h = sol.t_events[2]
+print(("Times, in years, at which CC at any depth crossed zero: "\
+      +', '.join(['%.2f']*len(h))+"") % tuple([Tstar * time for time in h]))
 print()
-y = sol.t_events[3]
-print(("Times, in years, at which CA + CC at any depth was larger than 1: "\
-      +', '.join(['%.2f']*len(y))+"") % tuple([Tstar * time for time in y]))
+k = sol.t_events[3]
+print(("Times, in years, at which CA + CC at any depth crossed one: "\
+      +', '.join(['%.2f']*len(k))+"") % tuple([Tstar * time for time in k]))
 print()
-z = sol.t_events[4]
-print(("Times, in years, at which the porosity at any depth was larger than 1: "\
-      +', '.join(['%.2f']*len(z))+"") % tuple([Tstar * time for time in z]))
+l = sol.t_events[4]
+print(("Times, in years, at which the porosity at any depth crossed one: "\
+      +', '.join(['%.2f']*len(l))+"") % tuple([Tstar * time for time in l]))
 print()
+m = sol.t_events[5]
+print(("Times, in years, at which U at any depth crossed zero: "\
+      +', '.join(['%.2f']*len(m))+"") % tuple([Tstar * time for time in m]))
+print()
+n = sol.t_events[6]
+print(("Times, in years, at which W at any depth crossed zero: "\
+      +', '.join(['%.2f']*len(n))+"") % tuple([Tstar * time for time in n]))
+print()
+
 print("Message from solve_ivp = {0}".format(sol.message))
 print()
 print("Time taken for solve_ivp is {0:.2f}s.".format(end_computing - start_computing))


### PR DESCRIPTION
Currently there are five branches in this repo, including main.

The Fiadeiro-Veronis branch achieves the desired result:
it integrates smoothly, without setting any limits on the states.
And the end result, after integrating over Tstar, is very similar to Fig 3e from l'Heureux.

It turns out that an explicit (in time) solver (_RK23_, i.e. Runge Kutta) from _solve_ivp_ performs equally well as an implicit (in time) solver like _BDF_ from _solve_ivp_, in the sense that both algorithms produce virtually the same plot after integrating over Tstar; the differences are really minor and can only be seen by blinking the two plots one after the other. This means the implicit solvers from solve_ivp and the Jacobian do not seem to be needed for computing Scenario A from l'Heureux.

Using _RK23_ it takes 27 minutes on a AMD EPYC 7402P 24-Core Processor, with 48 logical cores to cover Tstar, while with _BDF_ it takes 3 hours and 3 minutes.
Towards the end of the integration the memory used is about 12 GB voor _RK23_ and something similar for _BDF_. So really huge.

We want to retain the full power of _solve_ivp_ and the Jacobian computation for integrating other scenarios that may need implicit (in time) solvers. This means we want to keep a branch that deploys the full power of _solve_ivp_, i.e. _solve_ivp_ without the py-pde wrapper, the _Use_solve_ivp_without_py-pde_wrapper_ branch. So we want to merge all branches derived from _Use_solve_ivp_without_py-pde_wrapper_ into _Use_solve_ivp_without_py-pde_wrapper_.

Yet it would also be good to have a branch that integrates Scenario A fast and with a low memory footprint. This should become the main branch. That fast and efficient integrator for Scenario A can possibly be provided by the py-pde solvers, i.e. using the full py-pde framework, part of which was abandoned in the _Use_solve_ivp_without_py-pde_wrapper_ branch.