### PR TITLE
Making sure that bottom boundary conditions are not enforced for CA and CC

### DIFF
--- a/LMAHeureuxPorosityDiffV2.py
+++ b/LMAHeureuxPorosityDiffV2.py
@@ -24,8 +24,8 @@ class LMAHeureuxPorosityDiff(PDEBase):
         # integration, by using only backward differencing for the spatial
         # derivatives in the right-hand sides of the time derivative equations
         # for CA and CC.
-        self.bc_CA = [{"value": CA0}, {"curvature" : 0}]
-        self.bc_CC = [{"value": CC0}, {"curvature": 0}]
+        self.bc_CA = [{"value": CA0}, {"value" : 1e99}]
+        self.bc_CC = [{"value": CC0}, {"value": 1e99}]
         self.bc_cCa = [{"value": cCa0}, {"derivative": 0}]
         self.bc_cCO3 = [{"value": cCO30}, {"derivative": 0}]
         self.bc_Phi = [{"value": Phi0}, {"derivative": 0}]

--- a/LMAHeureuxPorosityDiffV2.py
+++ b/LMAHeureuxPorosityDiffV2.py
@@ -17,6 +17,13 @@ class LMAHeureuxPorosityDiff(PDEBase):
         self.CaSurface = CaSurface
         self.CO3Surface = CO3Surface
         self.PorSurface = PorSurface
+        # There are no bottom boundary conditions for CA and CC in equations 
+        # 35 from L'Heureux, but py-pde demands left and right boundary 
+        # conditions. This means that '"curvature" : 0' is a dummy boundary
+        # condition. We will make sure that it does not leak into our 
+        # integration, by using only backward differencing for the spatial
+        # derivatives in the right-hand sides of the time derivative equations
+        # for CA and CC.
         self.bc_CA = [{"value": CA0}, {"curvature" : 0}]
         self.bc_CC = [{"value": CC0}, {"curvature": 0}]
         self.bc_cCa = [{"value": cCa0}, {"derivative": 0}]
@@ -128,18 +135,13 @@ class LMAHeureuxPorosityDiff(PDEBase):
         one_minus_Phi = 1 - Phi
         U = self.presum + self.rhorat * Phi ** 3 * F /one_minus_Phi
 
-        # Choose either forward or backward differencing for CA and CC
-        # depending on the sign of U
-
+        # Enforce no bottom boundary condition for CA and CC by using
+        # backwards differencing only.
         CA_grad_back = CA._apply_operator("grad_back", self.bc_CA)
-        CA_grad_forw = CA._apply_operator("grad_forw", self.bc_CA)
-        CA_grad = ScalarField(state.grid, np.where(U.data>0, CA_grad_back.data, \
-            CA_grad_forw.data))
+        CA_grad = CA_grad_back
 
         CC_grad_back = CC._apply_operator("grad_back", self.bc_CC)
-        CC_grad_forw = CC._apply_operator("grad_forw", self.bc_CC)
-        CC_grad = ScalarField(state.grid, np.where(U.data>0, CC_grad_back.data, \
-            CC_grad_forw.data))
+        CC_grad = CC_grad_back
 
         W = self.presum - self.rhorat * Phi ** 2 * F
         
@@ -234,10 +236,11 @@ class LMAHeureuxPorosityDiff(PDEBase):
         Peclet_min = self.Peclet_min
         Peclet_max = self.Peclet_max
         delta_x = state.grid._axes_coords[0][1] - state.grid._axes_coords[0][0]
+
+        # Enforce no bottom boundary condition for CA and CC by using
+        # backwards differencing only.
         grad_back_CA = state.grid.make_operator("grad_back", bc = self.bc_CA)
-        grad_forw_CA = state.grid.make_operator("grad_forw", bc = self.bc_CA)
         grad_back_CC = state.grid.make_operator("grad_back", bc = self.bc_CC)
-        grad_forw_CC = state.grid.make_operator("grad_forw", bc = self.bc_CC)
         grad_back_cCa = state.grid.make_operator("grad_back", bc = self.bc_cCa)
         grad_forw_cCa = state.grid.make_operator("grad_forw", bc = self.bc_cCa)
         laplace_cCa = state.grid.make_operator("laplace", bc = self.bc_cCa)
@@ -256,11 +259,9 @@ class LMAHeureuxPorosityDiff(PDEBase):
             # either one of them, based on the sign of U.
             CA = state_data[0]
             CA_grad_back = grad_back_CA(CA)
-            CA_grad_forw = grad_forw_CA(CA)
 
             CC = state_data[1]
             CC_grad_back = grad_back_CC(CC)
-            CC_grad_forw = grad_forw_CC(CC)
 
             cCa = state_data[2]
             cCa_grad_back = grad_back_cCa(cCa)
@@ -314,12 +315,10 @@ class LMAHeureuxPorosityDiff(PDEBase):
 
                 U[i] = presum + rhorat * Phi[i] ** 3 * F[i]/ (1 - Phi[i])
 
-                if U[i] > 0:
-                    CA_grad[i] = CA_grad_back[i]
-                    CC_grad[i] = CC_grad_back[i]
-                else:
-                    CA_grad[i] = CA_grad_forw[i]
-                    CC_grad[i] = CC_grad_forw[i]
+                # Enforce no bottom boundary condition for CA and CC by using
+                # backwards differencing only.
+                CA_grad[i] = CA_grad_back[i]
+                CC_grad[i] = CC_grad_back[i]
 
                 W[i] = presum - rhorat * Phi[i] ** 2 * F[i]
 


### PR DESCRIPTION
There are no bottom boundary conditions for CA and CC in equations 35 from L'Heureux, but py-pde demands left and right boundary  conditions. This means that '"curvature" : 0' is a dummy boundary condition. We will make sure that it does not leak into our integration, by using only backward differencing for the spatial derivatives in the right-hand sides of the time derivative equations for CA and CC.

_I will submit a similar PR to merge into the `Use_solve_ivp_without_py-pde_wrapper` as well, since we want to maintain that branch._