### PR TITLE
Bugs fixed from exporting data after one millionth of tstar

### DIFF
--- a/marlpde/parameters.py
+++ b/marlpde/parameters.py
@@ -155,7 +155,6 @@ class Solver:
     So parameters like time interval, time step and tolerance.
     '''
     dt: float     = 1.e-6
-    eps: float    = 1.e-2
     # T* is more suitable as a default value
     # than the original value (100_000 years).
     tmax: float     = Map_Scenario().Tstar

--- a/marlpde/parameters.py
+++ b/marlpde/parameters.py
@@ -160,8 +160,6 @@ class Solver:
     # than the original value (100_000 years).
     tmax: float     = Map_Scenario().Tstar
     # timesteps in between writing.
-    outt: int     =   1_000
-    outx: int     =  25_000
     N: int        = 200
     solver: str   = "explicit"
     scheme: str   = "rk"

--- a/marlpde/parameters.py
+++ b/marlpde/parameters.py
@@ -158,7 +158,7 @@ class Solver:
     eps: float    = 1.e-2
     # T* is more suitable as a default value
     # than the original value (100_000 years).
-    tmax: int     = Map_Scenario().Tstar
+    tmax: float     = Map_Scenario().Tstar
     # timesteps in between writing.
     outt: int     =   1_000
     outx: int     =  25_000


### PR DESCRIPTION
Some lessons learned here from trying to extract data after 1e-6 * Tstar.

It turns out that `outt` and  `outx` are redundant.
They were remnants from `astro-turing/lheureux/marlpde/marlpde.py` on which `parameters.py` was based and not deleted, erroneously.

Also `eps` is not propagated. It should be either `tolerance` or `maxerror`, but that depends on the type of solver. Because of this divergence, it is not trivial to define a similar quantity here, in `parameters.py`; users should probably add it to the `eq.solve` call in `Evolve_scenario.py`, once they have set their type of solver in `parameters.py`.

Finally, `tmax` should be `float`, not an `int`.